### PR TITLE
Add percents to argument of darken()

### DIFF
--- a/osm-bright/base.mss
+++ b/osm-bright/base.mss
@@ -64,11 +64,11 @@
 #buildings[zoom>=12][zoom<=16] {
   polygon-fill:@building;
   [zoom>=14] {
-    line-color:darken(@building,5);
+    line-color:darken(@building,5%);
     line-width:0.2;
   }
   [zoom>=16] {
-    line-color:darken(@building,10);
+    line-color:darken(@building,10%);
     line-width:0.4;
   }
 }


### PR DESCRIPTION
Latest toolchain (mapnik 2.2 carto > 0.9.4) doesn't understand unitless argument.
Buildings get black borders instead of slightly darkened.
