### PR TITLE
Support arabic fonts

### DIFF
--- a/osm-bright/palette.mss
+++ b/osm-bright/palette.mss
@@ -21,12 +21,36 @@
 Map { font-directory: url(./fonts); }
 
 /* set up font sets for various weights and styles */
-@sans_lt:           "Open Sans Regular","DejaVu Sans Book","unifont Medium";
-@sans_lt_italic:    "Open Sans Italic","DejaVu Sans Italic","unifont Medium";
-@sans:              "Open Sans Semibold","DejaVu Sans Book","unifont Medium";
-@sans_italic:       "Open Sans Semibold Italic","DejaVu Sans Italic","unifont Medium";
-@sans_bold:         "Open Sans Bold","DejaVu Sans Bold","unifont Medium";
-@sans_bold_italic:  "Open Sans Bold Italic","DejaVu Sans Bold Italic","unifont Medium";
+@sans_lt:       "Open Sans Regular", "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
+
+
+@sans_lt_italic:    "Open Sans Oblique", "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
+
+
+@sans:          "Open Sans Semibold", "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
+
+@sans_italic:   "Open Sans Semibold Italic",  "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
+
+
+@sans_bold:  "Open Sans Bold", "DejaVu Sans Bold", "Arundina Sans Bold", "Padauk Bold", "Mukti Narrow Bold", "TSCu_Paranar Bold", "Mallige Bold",
+             "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+             "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+             "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
+
+@sans_bold_italic:  "Open Sans Bold Italic","DejaVu Sans Bold Oblique", "DejaVu Sans Oblique", "Arundina Sans Italic", "TSCu_Paranar Italic", "Mallige NormalItalic",
+                "DejaVu Sans Book", "Arundina Sans Regular", "Padauk Regular", "Khmer OS Metal Chrieng Regular",
+                "Mukti Narrow Regular", "gargi Medium", "TSCu_Paranar Regular", "Tibetan Machine Uni Regular", "Mallige Normal",
+                "Droid Sans Fallback Regular", "Unifont Medium", "unifont Medium";
 
 /* Some fonts are larger or smaller than others. Use this variable to
    globally increase or decrease the font sizes. */


### PR DESCRIPTION
The default fonts (Open *, and DejaVu *) don't have arabic characters.

When you use them, you get unicode boxes for many placenames.
![osmbright](https://cloud.githubusercontent.com/assets/1547/8871731/c965b646-31f7-11e5-92e3-49149c156c63.png)

unifont does, but it also shows a character for the left-to-right mark, and hence unsuitable.

![osmbright-unifont](https://cloud.githubusercontent.com/assets/1547/8871776/1d6e93e8-31f8-11e5-964a-d19cd417c055.png)

_(You can see the faint LRM at the left of each placename in this image)_

By adding in the fonts that the https://github.com/gravitystorm/openstreetmap-carto/ project uses, we can get much better font coverage, with the results looking like this:

![osmbright-proper-fonts](https://cloud.githubusercontent.com/assets/1547/8871812/6c67ff7a-31f8-11e5-88f1-c5d6095393c0.png)
