### PR TITLE
Fixed osm-bright.osm2pgsql.mml

### DIFF
--- a/osm-bright/osm-bright.osm2pgsql.mml
+++ b/osm-bright/osm-bright.osm2pgsql.mml
@@ -583,5 +583,5 @@
   "maxzoom": 18, 
   "minzoom": 0, 
   "name": "OSM Bright", 
-  "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
+  "srs": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over"
 }


### PR DESCRIPTION
Fixed an inconsistency that causes the error: Cannot initialize proj_transform for given projections without proj4 support (-DMAPNIK_USE_PROJ4).

This was happeneing due to a missing decmal point in the mml file.

https://github.com/Overv/openstreetmap-tile-server/issues/391